### PR TITLE
Error out appropriately if the git clone fails

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,7 +47,7 @@ define ohmyzsh::install(
 
   exec { "ohmyzsh::git clone ${name}":
     creates => "${home}/.oh-my-zsh",
-    command => "git clone https://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh",
+    command => "git clone https://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh || rmdir ${home}/.oh-my-zsh",
     path    => ['/bin', '/usr/bin'],
     onlyif  => "getent passwd ${name} | cut -d : -f 6 | xargs test -e",
     user    => $name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,7 +47,7 @@ define ohmyzsh::install(
 
   exec { "ohmyzsh::git clone ${name}":
     creates => "${home}/.oh-my-zsh",
-    command => "git clone https://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh || rmdir ${home}/.oh-my-zsh",
+    command => "git clone https://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh || rmdir ${home}/.oh-my-zsh && exit 1",
     path    => ['/bin', '/usr/bin'],
     onlyif  => "getent passwd ${name} | cut -d : -f 6 | xargs test -e",
     user    => $name,


### PR DESCRIPTION
A minor fix for puppet to error out appropriately if the git clone fails.

Currently if the git clone fails, it leaves behind an empty .oh-my.zsh directory which causes more errors later, even if the git clone access issue is resolved.
