### PR TITLE
Formatted to ensure correct return code on clone

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,7 +47,7 @@ define ohmyzsh::install(
 
   exec { "ohmyzsh::git clone ${name}":
     creates => "${home}/.oh-my-zsh",
-    command => "git clone https://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh || rmdir ${home}/.oh-my-zsh && exit 1",
+    command => "git clone https://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh || (rmdir ${home}/.oh-my-zsh && exit 1)",
     path    => ['/bin', '/usr/bin'],
     onlyif  => "getent passwd ${name} | cut -d : -f 6 | xargs test -e",
     user    => $name,

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -23,7 +23,7 @@ describe 'ohmyzsh::install' do
       it do
         should contain_exec("ohmyzsh::git clone #{user}")
           .with_creates("#{values[:expect][:home]}/.oh-my-zsh")
-          .with_command("git clone https://github.com/robbyrussell/oh-my-zsh.git #{values[:expect][:home]}/.oh-my-zsh || rmdir #{values[:expect][:home]}/.oh-my-zsh && exit 1")
+          .with_command("git clone https://github.com/robbyrussell/oh-my-zsh.git #{values[:expect][:home]}/.oh-my-zsh || (rmdir #{values[:expect][:home]}/.oh-my-zsh && exit 1)")
           .with_user(user)
       end
       it do


### PR DESCRIPTION
Due to operator precedence, the original code returned 1 even when the git clone was successful. This should resolve the problem.
